### PR TITLE
Keep SCX fine-scroll discard from clipping left-edge windows

### DIFF
--- a/src/GPU.cpp
+++ b/src/GPU.cpp
@@ -460,7 +460,10 @@ void GPU::CheckForWindowTrigger() {
         windowActivatePending_ = false;
         // A window with WX <= 7 triggers mid-warmup (dot 85 + WX); its first
         // 7 - WX pixels pop into the offscreen dots, left-clipping the first
-        // window tile, and any unconsumed SCX fine-scroll discards stack on top
+        // window tile. The SCX fine-scroll discard belongs to the background,
+        // so an activation cancels any unconsumed discards rather than letting
+        // them eat window pixels — except at WX = 0, whose delayed trigger
+        // lets the SCX stall play out, stacking under the window's clip
         if (windowWasActiveThisLine_) windowLineCounter_++;
         windowWasActiveThisLine_ = true;
         isFetchingWindow_ = true;
@@ -468,7 +471,10 @@ void GPU::CheckForWindowTrigger() {
         fetcherState_ = FetcherState::GetTile;
         fetcherDelay_ = 0;
         fetcherTileX_ = 0;
-        if (pixelsDrawn == 0) initialScrollXDiscard_ += 7 - windowX;
+        if (pixelsDrawn == 0) {
+            if (windowX != 0) initialScrollXDiscard_ = 0;
+            initialScrollXDiscard_ += 7 - windowX;
+        }
     } else if (windowTriggeredThisFrame && pixelsDrawn != 0 &&
                windowMatchLatch_ && !matched && initialScrollXDiscard_ == 0 &&
                fetcherState_ == FetcherState::PushToFIFO && fetcherDelay_ == 0 && backgroundQueue.empty()) {


### PR DESCRIPTION
A window activating at pixel 0 (WX <= 7) now cancels any unconsumed SCX fine-scroll discards instead of letting them drop its first pixels. The discard belongs to the background; the one-dot WX trigger had let it survive into the window restart, shifting left-edge windows horizontally whenever SCX & 7 was nonzero (the Pokemon Crystal location-sign skew). WX = 0 keeps stacking the discards under its 7-pixel clip, as pinned by m3_window_timing_wx_0.